### PR TITLE
feat(cli): specify root directory as a CLI argument

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,10 @@ alias l := lint
 init:
     cargo binstall cargo-shear taplo-cli typos-cli -y
 
+# Run Oxbuild (dev build, not optimized)
+oxbuild *ARGS:
+    cargo oxbuild {{ARGS}}
+
 # Apply formatting fixes
 fmt:
     @cargo fmt --all


### PR DESCRIPTION
You can now run
```sh
oxbuild path/to/root-dir
```

Instead of needing to be cd-ed into `root-dir`. Also supports error recovery if a path to a `package.json` file is provided instead of a directory.