### PR TITLE
feat: respect `stripInternal` compiler option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,12 +711,13 @@ dependencies = [
 
 [[package]]
 name = "oxc"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769a805a19845c860d2beb06d45a75c7697d5521a6c69ed20dbeba274001806e"
+checksum = "e5ab4cb60ae16fd5b9a8e7c7716eed450551e810f9232a9c9cd01d997a99cd57"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
+ "oxc_cfg",
  "oxc_codegen",
  "oxc_diagnostics",
  "oxc_index",
@@ -748,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e2199d2af8190a7b9882a17163c215429492b1b7224266a73cf6bf9f941402"
+checksum = "9186b2689dd687b435b54ff13a5f8673f8d7d6cd51211f514f9a9fc7f4ca64b6"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -758,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecbd3d3952245647faf308411e107cb5ef51a40b454047286be8ac9fe72238a"
+checksum = "d90e2d0a935fa2a9271a37e180e0725a902450474a0f2e8d104fb643f29cce67"
 dependencies = [
  "bitflags",
  "num-bigint",
@@ -773,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45160ddd52cf11b64c81bfe0bcee58297e2f5dbd6eaffe184e59ef4be52317c7"
+checksum = "a2b1072cb32335b47745c9ea9d614a6d5d36ba9f528fce1da428d5f7e20c3ed1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,12 +785,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_cfg"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a432722c19a1104a12acb88c32e58e0d01f0a445790e230b2805260651a95812"
+checksum = "10ead2bcd74b8b7f6dae07b698fd516c28cecb988ccc0d53389929ebe753b40e"
 dependencies = [
  "bitflags",
  "itertools",
+ "nonmax",
+ "oxc_index",
  "oxc_syntax",
  "petgraph",
  "rustc-hash",
@@ -797,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99256221928bcdd1168c027b6733a56e4beeb3d0b3172378e1e870ccf52a0bee"
+checksum = "11ba2b4b1f0dac2bc6cbb172d53bf8685153d56938682716ed1bf96489b86048"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -817,42 +820,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_diagnostics"
-version = "0.29.0"
+name = "oxc_data_structures"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35899f1b231c8aaeac1a30bf44cfb3763aa850bbe6cb43b21c6add46dec1f86"
+checksum = "311c92c32f008e000713bb9b0f410a9543985dcad9bbe9a60d6b84ed98b40663"
+dependencies = [
+ "assert-unchecked",
+]
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1421cd82c209a7dfc830fdd09b5c6372e28dfc419e9e67868c6159ab5c127b"
 dependencies = [
  "miette",
  "owo-colors",
+ "rustc-hash",
  "textwrap",
  "unicode-width",
 ]
 
 [[package]]
 name = "oxc_index"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81780683e8fbbceabfd750df8773cfdb2e0b801d58449ae01353b31a505cdb3"
+checksum = "cb46cc4ce3d5820ad5e5737f84f5206307b293f9984f9da219ac51ccdc0ea4c8"
 
 [[package]]
 name = "oxc_isolated_declarations"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c42fb9aae5efff14c83658ab4b7136f97e8c175f04ffa06bba9bef87b092a44"
+checksum = "9b07798508cef6d679768458081e71bcaff5efb0e113af65d910dd4995815037"
 dependencies = [
+ "bitflags",
  "oxc_allocator",
  "oxc_ast",
  "oxc_diagnostics",
  "oxc_span",
  "oxc_syntax",
+ "oxc_syntax_operations",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_mangler"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ce9dd92f66220ee649bd50541be9c3f2bfa8545d1919d78bf958de778dc1d1"
+checksum = "34bf54ed3c3706e4d690e48ebf62208b76aa1fcbeebb024939517d8bbd94b24a"
 dependencies = [
  "itertools",
  "oxc_ast",
@@ -863,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfe72ae236510ef3b5a08f668556a1023ae3073ce5f36a8becd200b8c830867"
+checksum = "aa495d133ed691322152ae51b8c14b211184ee9d2820a3616699015e6a5d4194"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -873,20 +888,20 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_codegen",
- "oxc_diagnostics",
  "oxc_mangler",
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
+ "oxc_syntax_operations",
  "oxc_traverse",
 ]
 
 [[package]]
 name = "oxc_parser"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4693f63ecc4892bdc823f427f7bf23a50cb71342f3b00d519127e6a9b39b3040"
+checksum = "8afe7b80a710daa7a07eec92bc46ed5a2d08581f15e833ee1eded5d929283893"
 dependencies = [
  "assert-unchecked",
  "bitflags",
@@ -900,15 +915,16 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
+ "oxc_syntax_operations",
  "rustc-hash",
  "seq-macro",
 ]
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f103d892a989080f0b1b9e3a12ab50263157d49e7c846217eb09d5f3521f2ee"
+checksum = "3bc9d3d0ca89ebc9860b6d458f671d06c887bf1fa08accf504c65b5824ea5d87"
 dependencies = [
  "oxc_allocator",
  "oxc_ast_macros",
@@ -921,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ca8f54988ba339150cb502d912bf55eef9e472a9d25451825bc9b72364717"
+checksum = "c4f87b5529862e35c8baef2e941109f0867f61f518009dc9f5cb26e9afd7d8fd"
 dependencies = [
  "assert-unchecked",
  "indexmap",
@@ -935,15 +951,16 @@ dependencies = [
  "oxc_index",
  "oxc_span",
  "oxc_syntax",
+ "oxc_syntax_operations",
  "phf",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_sourcemap"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39a3162497bdddab70d44e796948b9bbec5b329aeffae705c37ffb8bf852fe1"
+checksum = "f252f58750ea738aae4bb6e0c586fda65d9ee1ae049ae6b8dee47c924172917d"
 dependencies = [
  "base64-simd",
  "cfg-if",
@@ -955,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fb7f7bbc22bbfc4bc95f318c6d2bfc5c74a30fca797f2afe12aeb3ff82a287"
+checksum = "5c6a6c56f8482e48b6b7a953e55efe59ea55a0f00451a3f3aaf3c09c955c11c0"
 dependencies = [
  "compact_str",
  "miette",
@@ -967,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42410ff993c86fc77db38331b7b85cba007bd1388832d3489556ac7446ebefe"
+checksum = "2e1b7860133b880b357bb400e12a791e86dd8165ebcbfda1f3b7f31dd2f645ab"
 dependencies = [
  "assert-unchecked",
  "bitflags",
@@ -986,22 +1003,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "oxc_transformer"
-version = "0.29.0"
+name = "oxc_syntax_operations"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab60e8865288c81dcaa78fd2407622f4f9d405c1caa5168eaeea224234ca31f"
+checksum = "509fc5ab630ee66ce1d6fcb41d07a646cc14d91014bf31b0c731d219d31018cf"
+dependencies = [
+ "oxc_ast",
+ "oxc_span",
+]
+
+[[package]]
+name = "oxc_transformer"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e20d1d83977f513b6f1292ab2aa9874008d882fa8e244ac7a17a28391f0ad0"
 dependencies = [
  "base64",
+ "cow-utils",
  "dashmap",
  "indexmap",
  "oxc-browserslist",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_data_structures",
  "oxc_diagnostics",
+ "oxc_parser",
  "oxc_regular_expression",
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
+ "oxc_syntax_operations",
  "oxc_traverse",
  "ropey",
  "rustc-hash",
@@ -1012,18 +1043,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7e5a561e9aefe8fb4805a38f8ab666ec3edb8b7c7dab25149fb99059cf1618"
+checksum = "6375550b295b182533490c6fa6bda263500708e0dade4e897156baeb73f86489"
 dependencies = [
  "compact_str",
  "itoa",
  "memoffset",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_data_structures",
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
+ "oxc_syntax_operations",
  "rustc-hash",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clap                = { version = "4.5.17", features = ["cargo"] }
 ignore              = { version = "0.4.23" }
 json-strip-comments = { version = "1.0.4" }
 miette              = { version = "7.2.0", features = ["fancy"] }
-oxc                 = { version = "0.29.0", features = ["full", "sourcemap", "isolated_declarations"] }
+oxc                 = { version = "0.31.0", features = ["full"] }
 package-json        = { version = "0.4.0" }
 serde               = { version = "1.0.210" }
 serde_json          = { version = "1.0.128" }

--- a/src/compiler/options.rs
+++ b/src/compiler/options.rs
@@ -3,11 +3,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::options::DeclarationsOptions;
+
 #[derive(Debug, Clone)]
 pub struct CompileOptions {
     root_dir: PathBuf,
     /// Emit .d.ts files using isolatedDeclarations.
-    d_ts: bool,
+    declarations_options: Option<DeclarationsOptions>,
 }
 
 impl Default for CompileOptions {
@@ -18,18 +20,26 @@ impl Default for CompileOptions {
 }
 
 impl CompileOptions {
+    #[must_use]
     pub fn new(root_dir: PathBuf) -> Self {
         assert!(root_dir.is_dir());
         assert!(root_dir.is_absolute());
+
         Self {
             root_dir,
-            d_ts: false,
+            declarations_options: None,
         }
     }
 
-    pub fn with_d_ts(mut self, value: bool) -> Self {
-        self.d_ts = value;
+    #[must_use]
+    pub fn with_d_ts(mut self, value: Option<DeclarationsOptions>) -> Self {
+        self.declarations_options = value;
         self
+    }
+
+    #[inline]
+    pub fn declarations_options(&self) -> Option<&DeclarationsOptions> {
+        self.declarations_options.as_ref()
     }
 
     pub(crate) fn resolve<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -9,12 +9,14 @@ use miette::{IntoDiagnostic, Report, Result, WrapErr};
 // use package_json::{PackageJson, PackageJsonManager};
 use serde::Deserialize;
 
-// use crate::error::AnyError;
-
+#[derive(Debug)]
 pub struct OxbuildOptions {
     pub root: Root,
-    /// Emit `.d.ts` files using `isolatedModules` option.
-    pub isolated_declarations: bool,
+    /// Emit `.d.ts` files using `isolatedDeclarations` option.
+    ///
+    /// When [`Some`], declarations will be emitted using the provided options.
+    /// When [`None`], declaration emit is disabled.
+    pub isolated_declarations: Option<DeclarationsOptions>,
     /// Path to the folder containing source files to compile.
     pub src: PathBuf,
     /// Path to output folder where compiled code will be written.
@@ -22,6 +24,11 @@ pub struct OxbuildOptions {
     pub num_threads: NonZeroUsize,
     // package_json: PackageJson,
     // tsconfig: Option<PathBuf>, // TODO
+}
+
+#[derive(Debug, Clone)]
+pub struct DeclarationsOptions {
+    pub strip_internal: bool,
 }
 
 impl OxbuildOptions {
@@ -80,10 +87,16 @@ impl OxbuildOptions {
         };
         assert!(dist.is_dir()); // FIXME: handle errors
 
-        let isolated_declarations = co
-            .and_then(|co| co.isolated_declarations)
-            // no tsconfig means they're using JavaScript. We can't emit .d.ts files in that case.
-            .unwrap_or(false);
+        // let strip_internal = co.and_then(|co| co.)
+
+        // no tsconfig means they're using JavaScript. We can't emit .d.ts files in that case.
+        let isolated_declarations = co.and_then(|co| {
+            co.isolated_declarations
+                .unwrap_or(false)
+                .then(|| DeclarationsOptions {
+                    strip_internal: co.strip_internal.unwrap_or(false),
+                })
+        });
 
         Ok(Self {
             root,
@@ -92,6 +105,11 @@ impl OxbuildOptions {
             dist,
             num_threads,
         })
+    }
+
+    #[inline]
+    pub fn emit_declarations(&self) -> bool {
+        self.isolated_declarations.is_some()
     }
 }
 
@@ -112,6 +130,7 @@ struct TsConfigCompilerOptions {
     // TODO: parse more fields as needed
     root_dir: Option<PathBuf>,
     out_dir: Option<PathBuf>,
+    strip_internal: Option<bool>,
     isolated_declarations: Option<bool>,
 }
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -22,7 +22,7 @@ pub struct WalkerBuilder {
 impl WalkerBuilder {
     pub fn new(options: OxbuildOptions, sender: DiagnosticSender) -> Self {
         let compile_options = CompileOptions::new(options.root.deref().to_path_buf())
-            .with_d_ts(options.isolated_declarations);
+            .with_d_ts(options.isolated_declarations.clone());
         Self {
             compile_options: Arc::new(compile_options),
             options: Arc::new(options),


### PR DESCRIPTION
- chore: bump `oxc` crate from 0.29.0 to 0.31.0
- feat: respect `stripInternal` in `tsconfig.json`
- fix: do not attempt to emit declaration files when `isolatedDeclarations` is not set to `true`